### PR TITLE
client: do not raise an exception for submit_sm_resp

### DIFF
--- a/smpplib/client.py
+++ b/smpplib/client.py
@@ -283,7 +283,7 @@ class Client(object):
                 self.send_pdu(p)
                 return
 
-            if p.is_error():
+            if p.command != 'submit_sm_resp' and p.is_error():
                 raise exceptions.PDUError(
                     '({}) {}: {}'.format(p.status, p.command,
                     consts.DESCRIPTIONS.get(p.status, 'Unknown status')), int(p.status))

--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -148,7 +148,7 @@ class Command(pdu.PDU):
                     value = self._generate_int(field)
                     body += value
                 elif param.type is str:
-                    value = self._generate_string(field)
+                    value = self._generate_string(field).encode()
                     body += value
                 elif param.type is ostr:
                     value = self._generate_ostring(field)


### PR DESCRIPTION
Allow the handler to use error status from the PDU