### PR TITLE
command: Pack struct in big-endian byte order

### DIFF
--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -268,9 +268,8 @@ class Command(pdu.PDU):
         Return (data, pos) tuple."""
 
         size = self.params[field].size
-        field_value = getattr(self, field)
-        unpacked_data = self._unpack(">" + self._pack_format(field),
-            data[pos:pos + size])
+        fmt = self._pack_format(field)
+        unpacked_data = struct.unpack(">" + fmt, data[pos:pos + size])
         field_value = ''.join(map(str, unpacked_data))
         setattr(self, field, field_value)
         pos += size

--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -269,7 +269,7 @@ class Command(pdu.PDU):
 
         size = self.params[field].size
         field_value = getattr(self, field)
-        unpacked_data = self._unpack(self._pack_format(field),
+        unpacked_data = self._unpack(">" + self._pack_format(field),
             data[pos:pos + size])
         field_value = ''.join(map(str, unpacked_data))
         setattr(self, field, field_value)

--- a/smpplib/command.py
+++ b/smpplib/command.py
@@ -168,7 +168,7 @@ class Command(pdu.PDU):
         fmt = self._pack_format(field)
         data = getattr(self, field)
         if data:
-            return struct.pack(fmt, data)
+            return struct.pack(">" + fmt, data)
         else:
             return consts.NULL_STRING
 

--- a/smpplib/pdu.py
+++ b/smpplib/pdu.py
@@ -132,10 +132,6 @@ class PDU(object):
         if len(data) > 16:
             self.parse_params(data[16:])
 
-    def _unpack(self, fmt, data):
-        """Unpack values. Uses struct.unpack. TODO: remove this"""
-        return struct.unpack(fmt, data)
-
     def generate(self):
         """Generate raw PDU"""
 


### PR DESCRIPTION
It's already done in all other integer types and was probably forgotten
here. It's not a big issue because this path is only called for sending
mandatory parameters, and all integer mandatory parameters I could find
are only 1 byte long. However, add it for completeness and to avoid any
future issues in case of refactor.