### PR TITLE
client.py: Allow and use a return value from message_received_handler()

### DIFF
--- a/smpplib/client.py
+++ b/smpplib/client.py
@@ -234,8 +234,10 @@ class Client(object):
 
     def _message_received(self, p):
         """Handler for received message event"""
-        self.message_received_handler(pdu=p)
-        dsmr = smpp.make_pdu('deliver_sm_resp', client=self)
+        status = self.message_received_handler(pdu=p)
+        if status is None:
+            status = consts.SMPP_ESME_ROK
+        dsmr = smpp.make_pdu('deliver_sm_resp', client=self, status=status)
         #, message_id=args['pdu'].sm_default_msg_id)
         dsmr.sequence = p.sequence
         self.send_pdu(dsmr)


### PR DESCRIPTION
_message_received():

In the case where one might want to return a status to SMSC based
on the outcome of handling of a deliver_sm, we need to be able to
return that status and use it in the creation of the deliver_sm_resp