### PR TITLE
gsm.py: Fix gsm_encode in Python 2.x

### DIFF
--- a/smpplib/gsm.py
+++ b/smpplib/gsm.py
@@ -8,10 +8,13 @@ from . import exceptions
 
 
 # from http://stackoverflow.com/questions/2452861/python-library-for-converting-plain-text-ascii-into-gsm-7-bit-character-set
-gsm = (six.u("@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1bÆæßÉ !\"#¤%&'()*+,-./0123456789:;<=>"
-             "?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ`¿abcdefghijklmnopqrstuvwxyzäöñüà"))
-ext = (six.u("````````````````````^```````````````````{}`````\\````````````[~]`"
-             "|````````````````````````````````````€``````````````````````````"))
+gsm = ("@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1bÆæßÉ !\"#¤%&'()*+,-./0123456789:;<=>"
+       "?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ`¿abcdefghijklmnopqrstuvwxyzäöñüà")
+ext = ("````````````````````^```````````````````{}`````\\````````````[~]`"
+       "|````````````````````````````````````€``````````````````````````")
+if six.PY2:
+    gsm = gsm.decode('utf-8')
+    ext = ext.decode('utf-8')
 
 
 class EncodeError(ValueError):


### PR DESCRIPTION
`gsm_encode` works incorrectly in Python 2.x, e.g. `"Test"` converts to `"pΠ¿¿I"`. This is because of:

> https://pythonhosted.org/six/#six.u
> On Python 2, `u()` doesn’t know what the encoding of the literal is. Each byte is **converted directly to the unicode codepoint of the same value**. Because of this, **it’s only safe to use `u()` with strings of ASCII data**.

For example looking at `gsm` constant:

```python
# Python 3:
In [13]: gsm.find('T')
Out[13]: 84

# Python 2 (because of multibyte characters in the beginning of the constant):
In [8]: gsm.find('T')
Out[8]: 112
```

The easiest way would be to import `unicode_literals` and/or use `u""` prefix but since you support 2.6 and <3.3 I decided to go with the simple `if`.